### PR TITLE
Worker API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 dependencies {
   // gradle
   compile gradleApi()
+  compile 'org.clojure:clojure:1.8.0'
 
   // compat testing
   compatTestCompile gradleTestKit()

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 dependencies {
   // gradle
   compile gradleApi()
-  compile 'org.clojure:clojure:1.8.0'
+  compileOnly 'org.clojure:clojure:1.8.0'
 
   // compat testing
   compatTestCompile gradleTestKit()

--- a/src/compatTest/clojure/gradle_clojure/compat_test/test_kit.clj
+++ b/src/compatTest/clojure/gradle_clojure/compat_test/test_kit.clj
@@ -33,7 +33,7 @@
 (defn- runner [args]
   (-> (GradleRunner/create)
       (.withProjectDir (-> *project-dir* .toFile))
-      (.withArguments (into-array String args))
+      (.withArguments (into-array String (conj args "--stacktrace")))
       (.withPluginClasspath)
       (.forwardOutput)))
 

--- a/src/main/java/gradle_clojure/clojure/ClojurePlugin.java
+++ b/src/main/java/gradle_clojure/clojure/ClojurePlugin.java
@@ -42,6 +42,7 @@ public class ClojurePlugin implements Plugin<Project> {
       ClojureCompile compile = (ClojureCompile) project.getTasks().getByName(javaConvention.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME).getCompileTaskName("clojure"));
       test.getConventionMapping().map("classpath", sourceSet::getRuntimeClasspath);
       test.getConventionMapping().map("namespaces", compile::findNamespaces);
+      test.dependsOn(compile);
     });
   }
 

--- a/src/main/java/gradle_clojure/clojure/tasks/ClojureCompile.java
+++ b/src/main/java/gradle_clojure/clojure/tasks/ClojureCompile.java
@@ -49,6 +49,7 @@ import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerExecutor;
 
 import gradle_clojure.clojure.tasks.internal.ClojureEval;
+import gradle_clojure.clojure.tasks.internal.ClojureRuntime;
 import gradle_clojure.clojure.tasks.internal.LineProcessingOutputStream;
 
 public class ClojureCompile extends AbstractCompile {
@@ -173,6 +174,9 @@ public class ClojureCompile extends AbstractCompile {
   }
 
   private void executeScript(String script, OutputStream stdout, OutputStream stderr) throws IOException {
+    FileCollection clojure = ClojureRuntime.findClojure(getProject(), getClasspath())
+        .orElseThrow(() -> new GradleException("No Clojure dependency found."));
+
     FileCollection classpath = getClasspath()
         .plus(getProject().files(getSourceRootsFiles()))
         .plus(getProject().files(getDestinationDir()));
@@ -187,6 +191,7 @@ public class ClojureCompile extends AbstractCompile {
         fork.setMaxHeapSize(options.getForkOptions().getMemoryMaximumSize());
         fork.setDefaultCharacterEncoding(StandardCharsets.UTF_8.name());
       });
+      config.classpath(clojure);
     });
 
     stdout.close();

--- a/src/main/java/gradle_clojure/clojure/tasks/internal/ClojureEval.java
+++ b/src/main/java/gradle_clojure/clojure/tasks/internal/ClojureEval.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gradle_clojure.clojure.tasks.internal;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import clojure.java.api.Clojure;
+import clojure.lang.IFn;
+
+public class ClojureEval implements Runnable {
+  private final String script;
+  private final String compileClasspath;
+
+  @Inject
+  public ClojureEval(String script, String compileClasspath) {
+    this.script = script;
+    this.compileClasspath = compileClasspath;
+  }
+
+  @Override
+  public void run() {
+    URL[] classpathUrls = Arrays.stream(compileClasspath.split(File.pathSeparator))
+        .map(ClojureEval::parseUrl)
+        .toArray(size -> new URL[size]);
+
+    ClassLoader parent = ClassLoader.getSystemClassLoader();
+    ClassLoader loader = new URLClassLoader(classpathUrls, parent);
+
+    Thread.currentThread().setContextClassLoader(loader);
+    // eval the script
+    IFn main = Clojure.var("clojure.main", "main");
+    main.invoke("--eval", script);
+  }
+
+  private static URL parseUrl(String path) {
+    try {
+      File file = new File(path);
+      return file.toURI().toURL();
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/gradle_clojure/clojure/tasks/internal/ClojureRuntime.java
+++ b/src/main/java/gradle_clojure/clojure/tasks/internal/ClojureRuntime.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gradle_clojure.clojure.tasks.internal;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
+
+public final class ClojureRuntime {
+  private static final Pattern JAR_NAME = Pattern.compile("clojure-(?:\\d+\\.)+jar");
+
+  private ClojureRuntime() {
+    // do not instantiate
+  }
+
+  public static Optional<FileCollection> findClojure(Project project, Iterable<File> files) {
+    return StreamSupport.stream(files.spliterator(), false)
+        .filter(file -> JAR_NAME.matcher(file.getName()).matches())
+        .<FileCollection>map(project::files)
+        .findAny();
+  }
+}


### PR DESCRIPTION
Converting our tasks to use the worker API.

On my machine, this cut our test suite (`./gradlew clean compatTest --no-daemon`) from 25 seconds to 22 seconds. Should add up more in practical use where you may be repeatedly running compilations.