### PR TITLE
add sun.reflect to allowedClasses.

### DIFF
--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/internal/ClojureWorkerClassLoader.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/internal/ClojureWorkerClassLoader.java
@@ -93,6 +93,7 @@ public class ClojureWorkerClassLoader extends URLClassLoader {
         "java.",
         "javax.",
         "jdk.",
+        "sun.reflect.",
         "com.sun.",
         "org.ietf.",
         "org.omg.",


### PR DESCRIPTION
Without this, compiling clojure.tools.nrepl.server failed for Android with the following error.
```
ERROR:  clojure.lang.Compiler.CompilerException   java.lang.NoClassDefFoundError: sun/reflect/MethodAccessorImpl, compiling:(server.clj:1:1)
```