### PR TITLE
Support custom nREPL middleware and handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ A Gradle plugin providing support for the Clojure and Clojurescript languages.
 ### Clojure Features
 
 - Packaging Clojure code (and/or AOT compiled classes) into a JAR
+- Package an Uberjar (via the Gradle [Shadow plugin](http://imperceptiblethoughts.com/shadow/))
 - AOT compilation
 - Running clojure.test tests (integrated into Gradle's [Test task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html))
-- Running an nREPL server
+- Running an nREPL server (supports custom middlewares or handler)
 
 ### ClojureScript Features
 

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,10 @@ if (System.env['CI']) {
 
   allprojects {
     tasks.withType(Test) { task ->
+      // Trying to avoid memory pressure in Circle CI
+      // Gradle closes some test kit processes after JVM shuts down
+      forkEvery = 1
+
       // End tests fast when a failure is found
       failFast = true
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,12 +92,24 @@ test {
 clojureRepl {
   port = 55555 // defaults to a random open port (which will be printed in the build output)
 
+  // handler and middleware are both optional, but don't provide both
+  handler = 'cider.nrepl/cider-nrepl-handler' // fully-qualified name of function
+  middleware = ['my.stuff/wrap-stuff'] // list of fully-qualified middleware function names (override any existing)
+  middleware 'dev/my-middleware', 'dev/my-other-middleware' // one or more full-qualified middleware function names (append to any existing)
+
   // clojureRepl provides fork options to customize the Java process for compilation
   options.forkOptions {
     memoryMaximumSize = '2048m'
     jvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005', '-Djava.awt.headless=true']
   }
 }
+```
+
+The `ClojureNRepl` task also supports command-line options for some of it's parameters. Multiple `middleware` must be specified as separate options.
+
+```
+./gradlew clojureRepl --port=1234 --handler=cider.nrepl/cider-nrepl-handler
+./gradlew clojureRepl --port=4321 --middleware=dev/my-middleware --middleware=dev/my-other-middleware
 ```
 
 ## Polyglot Projects

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -73,6 +73,50 @@ Ensure your main namespace has `(:gen-class)` in the `ns` declaration:
 
 Read the [Shadow Plugin User Guide](http://imperceptiblethoughts.com/shadow/). for full details on their other features.
 
+## How do I use CIDER?
+
+[CIDER](https://cider.readthedocs.io/en/latest/) is a Clojure development environment for Emacs.
+
+Right now you need to manually add the dependency and specify the handler/middleware.
+
+Either apply to all of your projects via an init script:
+
+**~/.gradle/init.d/cider.gradle**
+```groovy
+allprojects {
+  plugins.withId('gradle-clojure.clojure') {
+    dependencies {
+      devCompile 'cider:cider-nrepl:0.17.0'
+    }
+
+    clojureRepl {
+      handler = 'cider.nrepl/cider-nrepl-middleware'
+    }
+  }
+}
+```
+
+Or add it manually to your project:
+
+**build.gradle**
+```groovy
+dependencies {
+  devCompile 'cider:cider-nrepl:0.17.0'
+}
+
+clojureRepl {
+  handler = 'cider.nrepl/cider-nrepl-middleware'
+}
+```
+
+Optionally, omit the handler config and provide it on the CLI:
+
+```
+./gradlew clojureRepl --handler=cider.nrepl/cider-nrepl-middleware
+```
+
+Once your REPL starts, use `cider-connect` within Emacs to connect to the port listed in your Gradle output.
+
 ## How do I build Clojure code that depends on Java code?
 
 You can compile Clojure code that depends on Java out of the box. Just put your

--- a/manual-test/build.gradle
+++ b/manual-test/build.gradle
@@ -18,4 +18,9 @@ repositories {
 dependencies {
   compile 'org.clojure:clojure:1.8.0'
   testCompile 'junit:junit:4.12'
+  devCompile 'cider:cider-nrepl:0.17.0'
+}
+
+clojureRepl {
+  handler = 'cider.nrepl/cider-nrepl-handler'
 }

--- a/modules/gradle-clojure-plugin/src/compatTest/clojure/gradle_clojure/compat_test/repl.clj
+++ b/modules/gradle-clojure-plugin/src/compatTest/clojure/gradle_clojure/compat_test/repl.clj
@@ -6,7 +6,8 @@
             [ike.cljj.file :as file]
             [clojure.tools.nrepl :as repl])
   (:import [org.gradle.testkit.runner TaskOutcome]
-           [gradle_clojure.compat_test LineProcessingWriter]))
+           [gradle_clojure.compat_test LineProcessingWriter]
+           [java.time LocalDate]))
 
 (defn parse-port [port]
   (fn [line]
@@ -24,19 +25,46 @@
         (finally
           (deliver port :build-failed))))))
 
-(defn eval-repl [client form]
-  (let [response (first (repl/message client {:op "eval" :code (pr-str form)}))]
+(defn send-repl [client msg]
+  (let [response (first (repl/message client msg))]
     (or (:value response) response)))
+
+(defn eval-repl [client form]
+  (send-repl client {:op "eval" :code (pr-str form)}))
+
+(defmacro with-client [[client project & args] & body]
+  `(let [port-promise# (promise)
+         build-thread# (Thread. #(start-repl port-promise# ~project ~@args))]
+     (.start build-thread#)
+     (let [port# (deref port-promise# 30000 :timeout)]
+       (if (int? port#)
+         (with-open [conn# (repl/connect :port port#)]
+           (let [~client (repl/client conn# 1000)]
+             (try
+               ~@body
+               (finally
+                 (repl/message ~client {:op "eval" :code (pr-str '(do (require 'gradle-clojure.tools.clojure-nrepl)  (gradle-clojure.tools.clojure-nrepl/stop!)))})))))
+         (throw (ex-info "Could not determine port REPL started on." {}))))))
 
 (deftest mixed-java-clojure
   (testing "Java classes are included on classpath of the REPL"
-    (let [port-promise (promise)
-          build-thread (Thread. #(start-repl port-promise "MixedJavaClojureTest"))]
-      (.start build-thread)
-      (let [port (deref port-promise 30000 :timeout)]
-        (if (int? port)
-          (with-open [conn (repl/connect :port port)]
-            (let [client (repl/client conn 1000)]
-              (is (= "\"Example2\"" (eval-repl client '(do (require 'cljSS.core) (cljSS.core/test-all)))))
-              (repl/message client {:op "eval" :code (pr-str '(do (require 'gradle-clojure.tools.clojure-nrepl) (gradle-clojure.tools.clojure-nrepl/stop!)))})))
-          (throw (ex-info "Could not determine port REPL started on." {})))))))
+    (with-client [client "MixedJavaClojureTest"]
+      (is (= "\"Example2\"" (eval-repl client '(do (require 'cljSS.core) (cljSS.core/test-all))))))))
+
+(deftest custom-handler
+  (testing "A custom nREPL handler function can be provided"
+    (with-client [client "MixedJavaClojureTest" "--handler=dev/silly-handler"]
+      (is (= "\"Keep trying!\"" (eval-repl client "nonsense"))))))
+
+(deftest custom-middleware
+  (testing "Custom nREPL middlewares can be provided"
+    (with-client [client "MixedJavaClojureTest" "--middleware=dev/current-date" "--middleware=dev/number-1"]
+      (is (= (#{(str (LocalDate/now)) (pr-str (str (LocalDate/now)))} (send-repl client {:op "now"}))))
+      ;; I have no idea why locally (Win10) I get "\"one\"" back, but in Circle CI, I get "one"
+      (is (#{"one" (pr-str "one")} (send-repl client {:op "num1"}))))))
+
+(deftest cider
+  (testing "CIDER middlewares can be provided"
+    (with-client [client "CiderTest" "--handler=cider.nrepl/cider-nrepl-handler"]
+      (is (= "0.17.0" (-> (send-repl client {:op "cider-version"}) :cider-version :version-string)))
+      (is (pr-str 7) (eval-repl client '(do (require 'basic-project.core) (basic-project/use-ns 4)))))))

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'gradle-clojure.clojure'
+}
+
+repositories {
+  mavenCentral()
+  mavenLocal()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
+}
+
+dependencies {
+  compile 'org.clojure:clojure:1.8.0'
+  testCompile 'junit:junit:4.12'
+  devCompile 'cider:cider-nrepl:0.17.0'
+}

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/clojure/basic_project/boom.clj
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/clojure/basic_project/boom.clj
@@ -1,0 +1,4 @@
+(ns basic-project.boom)
+
+(defn stuff [x]
+  (+ x 3))

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/clojure/basic_project/core.clj
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/clojure/basic_project/core.clj
@@ -1,0 +1,17 @@
+(ns basic-project.core
+  (:require [clojure.java.io :as io]
+            [basic-project.boom :as boom]))
+
+(defprotocol ITest)
+
+(defn hello [name]
+  (println "Generating message for" name)
+  (str "Hello " name))
+
+(defn bad [name]
+  (.endsWith name " Smith"))
+
+(defn use-ns [x]
+  (println "This is answer: " (boom/stuff x)))
+
+(println (slurp (io/resource "file.txt")))

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/clojure/basic_project/utils.clj
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/clojure/basic_project/utils.clj
@@ -1,0 +1,1 @@
+(ns basic-project.utils)

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/resources/file.txt
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/main/resources/file.txt
@@ -1,0 +1,1 @@
+Stuff is in this file!!!

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/test/clojure/basic_project/core_test.clj
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/src/test/clojure/basic_project/core_test.clj
@@ -1,0 +1,6 @@
+(ns basic-project.core-test
+  (:require [basic-project.core :refer [hello]]
+            [clojure.test :refer :all]))
+
+(deftest test-hello
+  (is (= "Hello World" (hello "World"))))

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/MixedJavaClojureTest/src/dev/clojure/dev.clj
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/MixedJavaClojureTest/src/dev/clojure/dev.clj
@@ -1,0 +1,33 @@
+(ns dev
+  (:require [clojure.tools.nrepl.transport :as t]
+            [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
+            [clojure.tools.nrepl.misc :refer [response-for]]
+            [gradle-clojure.tools.clojure-nrepl :as repl])
+  (:import [java.time LocalDate]))
+
+(def ops (atom 2))
+
+(defn silly-handler [{:keys [code transport] :as msg}]
+  (if (< 0 (swap! ops dec))
+    (t/send transport (response-for msg :status :done :value (pr-str "Keep trying!")))
+    (repl/stop!)))
+
+(defn current-date [h]
+  (fn [{:keys [op transport] :as msg}]
+    (if (= "now" op)
+      (t/send transport (response-for msg :status :done :value (str (LocalDate/now))))
+      (h msg))))
+
+(set-descriptor! #'current-date
+  {:handles {"now" {:doc "Returns the current date."
+                    :returns {"value" "The current date as an ISO-8601 string."}}}})
+
+(defn number-1 [h]
+  (fn [{:keys [op transport] :as msg}]
+    (if (= "num1" op)
+      (t/send transport (response-for msg :status :done :value "one"))
+      (h msg))))
+
+(set-descriptor! #'number-1
+  {:handles {"num1" {:doc "Returns the number 1."}
+                    :returns {"value" "The number 1."}}})


### PR DESCRIPTION
## Context

Via both task config and CLI options, you can now specify a custom
handler function or a list of middleware to use in your nREPL server.

Notably, this now allows you to use CIDER with Gradle.

I've done an automated test that CIDER middleware works, but need to do a manual test that actually uses Emacs to validate this.

**EDIT** Seems to work OK in Spacemacs. Granted I had no idea what I was doing, but a REPL started and it said CIDER in it, and eval'd things correctly.

**Related issues:** #60

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/gradle-clojure/gradle-clojure/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Provide functional tests. (under `modules/gradle-clojure-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch for commit statuses once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.
