### PR TITLE
Fix incorrect docs for Cider nREPL handler.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,7 +90,7 @@ allprojects {
     }
 
     clojureRepl {
-      handler = 'cider.nrepl/cider-nrepl-middleware'
+      handler = 'cider.nrepl/cider-nrepl-handler'
     }
   }
 }
@@ -105,14 +105,14 @@ dependencies {
 }
 
 clojureRepl {
-  handler = 'cider.nrepl/cider-nrepl-middleware'
+  handler = 'cider.nrepl/cider-nrepl-handler'
 }
 ```
 
 Optionally, omit the handler config and provide it on the CLI:
 
 ```
-./gradlew clojureRepl --handler=cider.nrepl/cider-nrepl-middleware
+./gradlew clojureRepl --handler=cider.nrepl/cider-nrepl-handler
 ```
 
 Once your REPL starts, use `cider-connect` within Emacs to connect to the port listed in your Gradle output.


### PR DESCRIPTION
## Context

The FAQ contains an incorrect Cider nREPL handler. All other instances reference the correct var.

**Related issues:**

## Contributor Checklist

- [ ] Review [Contributing Guidelines](https://github.com/gradle-clojure/gradle-clojure/blob/master/.github/CONTRIBUTING.md).
- [ ] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [ ] Provide functional tests. (under `modules/gradle-clojure-plugin/src/compatTest`)
- [ ] Update documentation for user-facing changes. (under `docs/`)
- [ ] Ensure all verification tasks pass locally. (`./gradlew check`)
- [ ] Ensure CI builds pass on all Java versions. (watch for commit statuses once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.