### PR TITLE
Remove extraneous space in nREPL message.

### DIFF
--- a/modules/gradle-clojure-tools/src/main/clojure/gradle_clojure/tools/clojure_nrepl.clj
+++ b/modules/gradle-clojure-tools/src/main/clojure/gradle_clojure/tools/clojure_nrepl.clj
@@ -24,7 +24,7 @@
                         :port control-port
                         :accept 'gradle-clojure.tools.clojure-nrepl/stop!})
   (let [server (nrepl/start-server :bind "localhost" :port repl-port :handler handler)]
-    (println "nREPL server started on port " repl-port)
+    (println "nREPL server started on port" repl-port)
     (println "Enter Ctrl-D to stop the REPL.")
     (deref (deref stopper))
     (server/stop-server "control")


### PR DESCRIPTION
- CIDER was expecting a message of form 'nREPL server started on port&nbsp;{{port}}'
  (https://github.com/clojure-emacs/cider/blob/master/nrepl-client.el#L1072)
  but we were outputting 'nREPL server started on port&nbsp;&nbsp;{{port}}'

## Context

Clojure's println joins arguments with a space.
```clj
(println "foo" "bar") => foo bar
nil
(println "foo " "bar") => foo  bar
nil
```
When CIDER starts a gradle-clojure REPL, it does not parse the port and as such, does not auto-connect.

**Related issues:**
#78 

## Contributor Checklist

- [X] Review [Contributing Guidelines](https://github.com/gradle-clojure/gradle-clojure/blob/master/.github/CONTRIBUTING.md).
- [X] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [ ] Provide functional tests. (under `modules/gradle-clojure-plugin/src/compatTest`)
- [X] Update documentation for user-facing changes. (under `docs/`)
- [X] Ensure all verification tasks pass locally. (`./gradlew check`)
- [ ] Ensure CI builds pass on all Java versions. (watch for commit statuses once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.