### PR TITLE
Use the non-contrib nrepl

### DIFF
--- a/modules/gradle-clojure-plugin/src/compatTest/projects/BasicClojureProjectTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/BasicClojureProjectTest/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
   mavenLocal()
 }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/BasicClojureScriptProjectTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/BasicClojureScriptProjectTest/build.gradle
@@ -5,6 +5,10 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
   mavenLocal()
 }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/CiderTest/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 repositories {
   mavenCentral()
-  mavenLocal()
   maven {
     name = 'Clojars'
     url = 'https://repo.clojars.org/'
   }
+  mavenLocal()
 }
 
 dependencies {

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/IncrementalCompilationTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/IncrementalCompilationTest/build.gradle
@@ -7,6 +7,10 @@ subprojects {
 
   repositories {
     mavenCentral()
+    maven {
+      name = 'Clojars'
+      url = 'https://repo.clojars.org/'
+    }
     mavenLocal()
   }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/LeinClojureProjectTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/LeinClojureProjectTest/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
   mavenLocal()
 }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/MixedClojureJavaTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/MixedClojureJavaTest/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
   mavenLocal()
 }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/MixedJavaClojureTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/MixedJavaClojureTest/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
   mavenLocal()
 }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/MultipleSourceSetsTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/MultipleSourceSetsTest/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
   mavenLocal()
 }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/TestFailureFailsBuildTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/TestFailureFailsBuildTest/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
   mavenCentral()
+  maven {
+    name = 'Clojars'
+    url = 'https://repo.clojars.org/'
+  }
   mavenLocal()
 }
 

--- a/modules/gradle-clojure-plugin/src/compatTest/projects/UberjarTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/UberjarTest/build.gradle
@@ -8,11 +8,11 @@ mainClassName = 'sample.core'
 
 repositories {
   mavenCentral()
-  mavenLocal()
   maven {
     name = 'Clojars'
     url = 'https://repo.clojars.org/'
   }
+  mavenLocal()
 }
 
 dependencies {

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojure/ClojureBasePlugin.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojure/ClojureBasePlugin.java
@@ -7,6 +7,7 @@ import gradle_clojure.plugin.clojure.tasks.ClojureCompile;
 import gradle_clojure.plugin.clojure.tasks.ClojureSourceSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ComponentModuleMetadataDetails;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.plugins.JavaBasePlugin;
@@ -26,6 +27,7 @@ public class ClojureBasePlugin implements Plugin<Project> {
     project.getPluginManager().apply(JavaBasePlugin.class);
 
     configureSourceSetDefaults(project);
+    configureModuleReplacements(project);
   }
 
   private void configureSourceSetDefaults(Project project) {
@@ -59,6 +61,13 @@ public class ClojureBasePlugin implements Plugin<Project> {
       compile.dependsOn(project.getTasks().getByName(sourceSet.getCompileJavaTaskName()));
       compile.dependsOn(project.getTasks().getByName(sourceSet.getProcessResourcesTaskName()));
       project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(compile);
+    });
+  }
+
+  private void configureModuleReplacements(Project project) {
+    project.getDependencies().getModules().module("org.clojure:tools.nrepl", module -> {
+      ComponentModuleMetadataDetails details = (ComponentModuleMetadataDetails) module;
+      details.replacedBy("nrepl:nrepl", "nREPL was moved out of Clojure Contrib to its own project.");
     });
   }
 }

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojure/ClojurePlugin.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojure/ClojurePlugin.java
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.SourceSet;
 
 public class ClojurePlugin implements Plugin<Project> {
   private static final String DEV_SOURCE_SET_NAME = "dev";
+  private static final String DEV_NREPL_CONFIGURATION_NAME = "devNRepl";
 
   @Override
   public void apply(Project project) {
@@ -56,6 +57,14 @@ public class ClojurePlugin implements Plugin<Project> {
     SourceDirectorySet mainClojure = new DslObject(main).getConvention().getPlugin(ClojureSourceSet.class).getClojure();
     SourceDirectorySet testClojure = new DslObject(test).getConvention().getPlugin(ClojureSourceSet.class).getClojure();
     SourceDirectorySet devClojure = new DslObject(dev).getConvention().getPlugin(ClojureSourceSet.class).getClojure();
+
+    Configuration nrepl = project.getConfigurations().create(DEV_NREPL_CONFIGURATION_NAME);
+    nrepl.defaultDependencies(deps -> {
+      deps.add(project.getDependencies().create("nrepl:nrepl:0.3.1"));
+    });
+    project.getConfigurations().getByName(dev.getCompileClasspathConfigurationName()).extendsFrom(nrepl);
+    project.getConfigurations().getByName(dev.getRuntimeClasspathConfigurationName()).extendsFrom(nrepl);
+
 
     dev.setCompileClasspath(project.files(
         test.getOutput(),

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/common/internal/ClojureExecSpec.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/common/internal/ClojureExecSpec.java
@@ -1,4 +1,4 @@
-package gradle_clojure.plugin.clojure.tasks;
+package gradle_clojure.plugin.common.internal;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/common/internal/ClojureExecutor.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/common/internal/ClojureExecutor.java
@@ -11,7 +11,6 @@ import java.util.Properties;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import gradle_clojure.plugin.clojure.tasks.ClojureExecSpec;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
@@ -19,7 +18,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.LogLevel;
 
 public final class ClojureExecutor {
-  private static final String NREPL_VERSION = "0.2.12";
   private static final String GRADLE_CLOJURE_VERSION = getVersion();
 
   private final Project project;
@@ -35,7 +33,7 @@ public final class ClojureExecutor {
   }
 
   public void exec(ClojureExecSpec cljSpec) {
-    FileCollection fullClasspath = cljSpec.getClasspath().plus(resolve(tools(), nrepl()));
+    FileCollection fullClasspath = cljSpec.getClasspath().plus(resolve(tools()));
     project.javaexec(spec -> {
       spec.setMain("clojure.main");
       spec.args("-m", cljSpec.getMain());
@@ -57,10 +55,6 @@ public final class ClojureExecutor {
 
   public Dependency tools() {
     return project.getDependencies().create("io.github.gradle-clojure:gradle-clojure-tools:" + GRADLE_CLOJURE_VERSION);
-  }
-
-  public Dependency nrepl() {
-    return project.getDependencies().create("org.clojure:tools.nrepl:" + NREPL_VERSION);
   }
 
   private static String getVersion() {

--- a/modules/gradle-clojure-tools/src/main/clojure/gradle_clojure/tools/clojure_nrepl.clj
+++ b/modules/gradle-clojure-tools/src/main/clojure/gradle_clojure/tools/clojure_nrepl.clj
@@ -23,7 +23,7 @@
   (server/start-server {:name "control"
                         :port control-port
                         :accept 'gradle-clojure.tools.clojure-nrepl/stop!})
-  (let [server (nrepl/start-server :bind "localhost" :port repl-port :handler handler)]
+  (let [server (nrepl/start-server :port repl-port :handler handler)]
     (println "nREPL server started on port" repl-port)
     (println "Enter Ctrl-D to stop the REPL.")
     (deref (deref stopper))


### PR DESCRIPTION
## Context

Development of nREPL has been moved out of Clojure Contrib, so we should
switch over to using that approach.

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/gradle-clojure/gradle-clojure/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Provide functional tests. (under `modules/gradle-clojure-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch for commit statuses once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.
