### PR TITLE
Resolve cljs output relative to source set output

### DIFF
--- a/modules/gradle-clojure-plugin/src/compatTest/projects/BasicClojureScriptProjectTest/build.gradle
+++ b/modules/gradle-clojure-plugin/src/compatTest/projects/BasicClojureScriptProjectTest/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 
 compileClojurescript {
   options {
-    outputTo = file("${destinationDir}/js/main.js")
-    outputDir = file("${destinationDir}/js/out")
+    outputTo = 'js/main.js'
+    outputDir = 'js/out'
     optimizations = "simple"
     main = "basic-project.core"
-    sourceMap = "${destinationDir}/js/main.js.map"
+    sourceMap = 'js/main.js.map'
 //    preloads = ["basic-project.core"]
 
 //    foreignLib {

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojurescript/ClojureScriptBasePlugin.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojurescript/ClojureScriptBasePlugin.java
@@ -50,7 +50,7 @@ public class ClojureScriptBasePlugin implements Plugin<Project> {
       compile.setSource(clojurescriptSourceSet.getClojureScript());
 
       Provider<FileCollection> classpath = project.provider(sourceSet::getCompileClasspath);
-      compile.setClasspath(project.files(classpath));
+      compile.getClasspath().from(classpath);
 
       DirectoryProperty buildDir = project.getLayout().getBuildDirectory();
       String outputDirPath = String.format("classes/%s/%s", clojurescriptSourceSet.getClojureScript().getName(), sourceSet.getName());
@@ -58,7 +58,7 @@ public class ClojureScriptBasePlugin implements Plugin<Project> {
 
       clojurescriptSourceSet.getClojureScript().setOutputDir(outputDir.map(dir -> dir.getAsFile()));
       ((DefaultSourceSetOutput) sourceSet.getOutput()).addClassesDir(() -> outputDir.get().getAsFile());
-      compile.setDestinationDir(outputDir.map(dir -> dir.getAsFile()));
+      compile.getDestinationDir().set(outputDir);
 
       project.getTasks().getByName(sourceSet.getClassesTaskName()).dependsOn(compile);
     });

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojurescript/tasks/ClojureScriptCompile.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojurescript/tasks/ClojureScriptCompile.java
@@ -9,23 +9,41 @@ import java.util.stream.Collectors;
 import gradle_clojure.plugin.clojure.tasks.ClojureCompile;
 import gradle_clojure.plugin.common.internal.ClojureExecutor;
 import org.gradle.api.Action;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.api.tasks.compile.AbstractCompile;
 
-public class ClojureScriptCompile extends AbstractCompile {
+public class ClojureScriptCompile extends SourceTask {
   private static final Logger logger = Logging.getLogger(ClojureCompile.class);
 
   private final ClojureExecutor clojureExecutor;
-
-  private final ClojureScriptCompileOptions options = new ClojureScriptCompileOptions();
+  private final DirectoryProperty destinationDir;
+  private final ConfigurableFileCollection classpath;
+  private final ClojureScriptCompileOptions options;
 
   public ClojureScriptCompile() {
     this.clojureExecutor = new ClojureExecutor(getProject());
+    this.destinationDir = getProject().getLayout().directoryProperty();
+    this.classpath = getProject().files();
+    this.options = new ClojureScriptCompileOptions(getProject(), destinationDir);
+  }
+
+  @OutputDirectory
+  public DirectoryProperty getDestinationDir() {
+    return destinationDir;
+  }
+
+  @Classpath
+  public ConfigurableFileCollection getClasspath() {
+    return classpath;
   }
 
   @Nested
@@ -38,9 +56,8 @@ public class ClojureScriptCompile extends AbstractCompile {
     return this;
   }
 
-  @Override
   @TaskAction
-  protected void compile() {
+  public void compile() {
     FileCollection classpath = getClasspath().plus(getProject().files(getSourceRootsFiles()));
 
     clojureExecutor.exec(spec -> {

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojurescript/tasks/Module.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/clojurescript/tasks/Module.java
@@ -4,22 +4,35 @@ package gradle_clojure.plugin.clojurescript.tasks;
 import java.io.File;
 import java.util.Set;
 
+import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 
 public class Module {
-  private File outputTo;
+  private final DirectoryProperty destinationDir;
+  private final RegularFileProperty outputTo;
   private Set<String> entries;
   private Set<String> dependsOn;
 
+  public Module(Project project, DirectoryProperty destinationDir) {
+    this.destinationDir = destinationDir;
+    this.outputTo = project.getLayout().fileProperty();
+  }
+
   @OutputFile
-  public File getOutputTo() {
+  public RegularFileProperty getOutputTo() {
     return outputTo;
   }
 
+  public void setOutputTo(String outputTo) {
+    this.outputTo.set(destinationDir.file(outputTo));
+  }
+
   public void setOutputTo(File outputTo) {
-    this.outputTo = outputTo;
+    this.outputTo.set(outputTo);
   }
 
   @Input

--- a/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/common/internal/Edn.java
+++ b/modules/gradle-clojure-plugin/src/main/java/gradle_clojure/plugin/common/internal/Edn.java
@@ -54,8 +54,8 @@ public class Edn {
 
   private static final Printer.Fn<ClojureScriptCompileOptions> CLOJURESCRIPT_COMPILE_OPTIONS_PRINTER = (self, printer) -> {
     Map<Object, Object> map = new LinkedHashMap<>();
-    map.put(newKeyword("output-to"), self.getOutputTo());
-    map.put(newKeyword("output-dir"), self.getOutputDir());
+    map.put(newKeyword("output-to"), self.getOutputTo().getAsFile().getOrNull());
+    map.put(newKeyword("output-dir"), self.getOutputDir().getAsFile().getOrNull());
     map.put(newKeyword("optimizations"), self.getOptimizations());
     map.put(newKeyword("main"), self.getMain());
     map.put(newKeyword("asset-path"), self.getAssetPath());
@@ -127,7 +127,7 @@ public class Edn {
 
   private static final Printer.Fn<Module> MODULE_PRINTER = (module, printer) -> {
     Map<Object, Object> map = new LinkedHashMap<>();
-    map.put(newKeyword("output-to"), module.getOutputTo());
+    map.put(newKeyword("output-to"), module.getOutputTo().getAsFile().getOrNull());
     map.put(newKeyword("entries"), module.getEntries());
     map.put(newKeyword("dependsOn"), module.getDependsOn());
     map.values().removeIf(Objects::isNull);


### PR DESCRIPTION
## Context

Instead of requiring someone to know where the output directory is, we
now support letting them pass in a String which will be resolved
relative to the source set's output directory.

So outputTo = 'js/main.js' should resolve to
'build/classes/clojurescript/main/js/main.js'.

**Related issues:**

## Contributor Checklist

- [x] Review [Contributing Guidelines](https://github.com/gradle-clojure/gradle-clojure/blob/master/.github/CONTRIBUTING.md).
- [x] Commits contain discrete changes, messages include context about why the change was made and reference the relevant issues.
- [x] Provide functional tests. (under `modules/gradle-clojure-plugin/src/compatTest`)
- [x] Update documentation for user-facing changes. (under `docs/`)
- [x] Ensure all verification tasks pass locally. (`./gradlew check`)
- [x] Ensure CI builds pass on all Java versions. (watch for commit statuses once the PR is opened)

  **TIP:** If troubleshooting a CI failure, look for the build scan URL near the bottom of the Gradle output.
